### PR TITLE
야무진 피알

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,19 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+[*.{ts,js}]
+indent_style = space
+indent_size = 4
+charset = utf-8
+
+# Matches the exact files either package.json or .travis.yml
+[package.json]
+indent_style = space
+indent_size = 2

--- a/.gitignore
+++ b/.gitignore
@@ -106,6 +106,9 @@ dist
 # Stores VSCode versions used for testing VSCode extensions
 .vscode-test
 
+# IDEA development environment files
+.idea
+
 # yarn v2
 .yarn/cache
 .yarn/unplugged

--- a/Server/Core/db.ts
+++ b/Server/Core/db.ts
@@ -1,9 +1,9 @@
-import mongoose from "mongoose";
+import mongoose, {ConnectionOptions} from "mongoose";
 import { IApplicantAccount, ApplicantAccountSchema } from "../Documents/Recruitment/AccountDocument";
 import { IRefreshToken, RefreshTokenSchema } from "../Documents/Recruitment/RefreshTokenDocument";
 
 const mongodbURI: string = process.env.MONGO_URI || 'mongodb://localhost:27017/portal_newbie_dev';
-const mongodbOption = {
+const mongodbOption: ConnectionOptions = {
     poolSize: 10,
     useNewUrlParser: true,
     useUnifiedTopology: true,

--- a/Server/README.md
+++ b/Server/README.md
@@ -5,6 +5,11 @@
 - __run `npm install` on root directory to install dependencies.__
 - **Please specify informations about api calls on this page for API calls. You can check example of documentation [here](https://gist.github.com/iros/3426278).**
 
+## Development Tooling
+
+* `.editorconfig` : indentation style : 4 spaces
+* `nodemon` : run `nodemon app.ts` at `GonPortal/Server` directory to automatically re-compile.
+
 ## API Reference
 - Newbie Recruitment
     - 

--- a/Server/package-lock.json
+++ b/Server/package-lock.json
@@ -1835,9 +1835,9 @@
       }
     },
     "pupa": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/pupa/-/pupa-2.1.0.tgz",
-      "integrity": "sha512-Pj8EhJzFiPwnf4dEXpuUWwH8M/Yl4vpl4cN2RX1i3R77DWvbY5ZPKni7CCKkOYxz+XKt2fieemsV+WTZbIlYzg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/pupa/-/pupa-2.1.1.tgz",
+      "integrity": "sha512-l1jNAspIBSFqbT+y+5FosojNpVpF94nlI+wDUpqP9enwOTfHx9f0gh5nB96vl+6yTpsJsypeNrwfzPrKuHB41A==",
       "dev": true,
       "requires": {
         "escape-goat": "^2.0.0"
@@ -2188,9 +2188,9 @@
       }
     },
     "term-size": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/term-size/-/term-size-2.2.0.tgz",
-      "integrity": "sha512-a6sumDlzyHVJWb8+YofY4TW112G6p2FCPEAFk+59gIYHv3XHRhm9ltVQ9kli4hNWeQBwSpe8cRN25x0ROunMOw==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/term-size/-/term-size-2.2.1.tgz",
+      "integrity": "sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==",
       "dev": true
     },
     "to-readable-stream": {


### PR DESCRIPTION
# 개발 내용
## `.editorconfig` 및 `nodemon`
- 코딩 스타일 규약 설정 : 스페이스바 4칸으로 인덴테이션, 마지막에 빈 whiteline 강제
- `nodemon`을 devDependency에 추가. 자동 재컴파일 가능. 사용법 `Server/README.md` 에 소개.

## account 생성 controller 수정
- validation function을 컨트롤러 밖으로 분리
- 데이터베이스 접근 방식 변경

### 기존 방법

`await and validate` -> `await and validate` -> ...
순차적으로 데이터베이스에 접근함

### 새로운 방법
`[validation logic, validation logic, ...]` -> `Promise.all`
확인하고 싶은 validation logic을 `Promise<void>[]`로 여러개 미리 설정함. (이때 실행되지는 않음.)
그 후에 `Promise.all` 로 비동기적으로 모든 로직을 한번에 실행. **단, 하나의 validation logic이라도** exception을 발생시키면(validation failure 발생) **모든** validation 이 취소됨.

아래는 기존 방법과 새로운 방법의 trade-off를 설명

#### Pros
`A, B, C` 를 확인하고자 할 경우, `C`만 validation failure가 일어난다고 할 때 기존 방법에서는 A, B를 항상 검사하므로 불필요한 workload 증가. 새로운 방법에서는 이론적으로 `A, B, C`가 동시에 일어난다고 하면 `C`가 실패하면 `A, B`도 즉시 종료되므로 불필요한 검사를 줄일 수 있음.

#### Cons

DB에 한번에 여러 connection을 보내기 때문에 workload peak가 오히려 증가할 수 있음.

쓸데없는 코드 복잡도 증가. 코드가 이해하기 어려움.